### PR TITLE
Pass device id on login request

### DIFF
--- a/app/src/main/java/ro/code4/monitorizarevot/ui/login/LoginActivity.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/login/LoginActivity.kt
@@ -1,6 +1,8 @@
 package ro.code4.monitorizarevot.ui.login
 
+import android.annotation.SuppressLint
 import android.os.Bundle
+import android.provider.Settings.Secure
 import androidx.lifecycle.Observer
 import kotlinx.android.synthetic.main.activity_login.*
 import org.koin.android.viewmodel.ext.android.viewModel
@@ -18,6 +20,7 @@ class LoginActivity : BaseActivity<LoginViewModel>() {
         get() = R.layout.activity_login
     override val viewModel: LoginViewModel by viewModel()
 
+    @SuppressLint("HardwareIds")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -25,8 +28,8 @@ class LoginActivity : BaseActivity<LoginViewModel>() {
             val user = User(
                 phone.text.toString(),
                 password.text.toString(),
-                "1234"
-            )//TODO replace with phone uiid  Settings.Secure.getString(getContentResolver(), Settings.Secure.ANDROID_ID);
+                Secure.getString(applicationContext.contentResolver, Secure.ANDROID_ID)
+            )
             viewModel.login(user)
         }
         appVersion.text = getString(R.string.app_version, BuildConfig.VERSION_NAME)


### PR DESCRIPTION
Used the suggested method from the `TODO` comment to get a unique device Id.
Based on [google best practices](https://developer.android.com/training/articles/user-data-ids) it's not the recommended one but should do the job.

Fixes #50 