### PR TITLE
Display the received notification in app when the user opens the app by pressing on a received notification

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
 // TODO: Uncomment this to enable FirebaseAnalytics and Crashlytics
-apply plugin: 'io.fabric'
+//apply plugin: 'io.fabric'
 
 static def getKey(String env, String key) {
     Properties props = new Properties()
@@ -164,4 +164,4 @@ dependencies {
 }
 
 // TODO: Uncomment this to enable FirebaseAnalytics and Crashlytics
-apply plugin: 'com.google.gms.google-services'
+//apply plugin: 'com.google.gms.google-services'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
 // TODO: Uncomment this to enable FirebaseAnalytics and Crashlytics
-//apply plugin: 'io.fabric'
+apply plugin: 'io.fabric'
 
 static def getKey(String env, String key) {
     Properties props = new Properties()
@@ -130,7 +130,7 @@ dependencies {
 
     // Firebase
     implementation "com.google.firebase:firebase-analytics:$firebaseVersion"
-    implementation 'com.google.firebase:firebase-messaging:20.0.0'
+    implementation 'com.google.firebase:firebase-messaging:20.0.1'
     implementation 'com.google.firebase:firebase-config:19.0.3'
     implementation "com.crashlytics.sdk.android:crashlytics:$crashlyticsVersion"
 
@@ -164,4 +164,4 @@ dependencies {
 }
 
 // TODO: Uncomment this to enable FirebaseAnalytics and Crashlytics
-//apply plugin: 'com.google.gms.google-services'
+apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/ro/code4/monitorizarevot/helper/Constants.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/helper/Constants.kt
@@ -18,4 +18,6 @@ object Constants {
     const val TYPE_MULTI_CHOICE_DETAILS = 3
 
     const val REMOTE_CONFIG_FILTER_DIASPORA_FORMS = "filter_diaspora_forms"
+    const val PUSH_NOTIFICATION_TITLE = "notification_title"
+    const val PUSH_NOTIFICATION_BODY = "notification_body"
 }

--- a/app/src/main/java/ro/code4/monitorizarevot/services/notification/NotificationService.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/services/notification/NotificationService.kt
@@ -18,7 +18,7 @@ class NotificationService : FirebaseMessagingService() {
     private fun showNotification(message: RemoteMessage) {
         message.notification?.let {
             App.instance.currentActivity?.runOnUiThread {
-                App.instance.currentActivity?.showPushNotification(it)
+                App.instance.currentActivity?.showPushNotification(it.title.orEmpty(), it.body.orEmpty())
             }
         }
     }

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/base/BaseActivity.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/base/BaseActivity.kt
@@ -54,11 +54,11 @@ abstract class BaseActivity<out T : BaseViewModel> : AppCompatActivity(), Layout
 
     }
 
-    fun showPushNotification(notification: RemoteMessage.Notification) {
+    fun showPushNotification(title: String, body: String) {
         if (!isFinishing && dialog == null) {
             dialog = AlertDialog.Builder(this, R.style.AlertDialog)
-                .setTitle(notification.title)
-                .setMessage(notification.body)
+                .setTitle(title)
+                .setMessage(body)
                 .setPositiveButton(R.string.push_notification_ok)
                 { p0, _ -> p0.dismiss() }
                 .setCancelable(false)

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/base/BaseActivity.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/base/BaseActivity.kt
@@ -54,15 +54,21 @@ abstract class BaseActivity<out T : BaseViewModel> : AppCompatActivity(), Layout
 
     }
 
-    fun showPushNotification(title: String, body: String) {
+    fun showPushNotification(title: String, body: String, okListener: (() -> Unit)? = null, dismissListener: (() -> Unit)? = null) {
         if (!isFinishing && dialog == null) {
             dialog = AlertDialog.Builder(this, R.style.AlertDialog)
                 .setTitle(title)
                 .setMessage(body)
                 .setPositiveButton(R.string.push_notification_ok)
-                { p0, _ -> p0.dismiss() }
+                { p0, _ ->
+                    okListener?.invoke()
+                    p0.dismiss()
+                }
                 .setCancelable(false)
-                .setOnDismissListener { dialog = null }
+                .setOnDismissListener {
+                    dismissListener?.invoke()
+                    dialog = null
+                }
                 .show()
         }
     }

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/main/MainActivity.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/main/MainActivity.kt
@@ -14,7 +14,6 @@ import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.app_bar_main.*
 import org.koin.android.viewmodel.ext.android.viewModel
 import ro.code4.monitorizarevot.R
-import ro.code4.monitorizarevot.helper.Constants
 import ro.code4.monitorizarevot.helper.callSupportCenter
 import ro.code4.monitorizarevot.helper.changePollingStation
 import ro.code4.monitorizarevot.helper.startActivityWithoutTrace
@@ -82,12 +81,6 @@ class MainActivity : BaseActivity<MainViewModel>() {
         viewModel.onLogoutLiveData().observe(this, Observer {
             startActivityWithoutTrace(LoginActivity::class.java)
         })
-
-        val notificationTitle = intent?.extras?.getString(Constants.PUSH_NOTIFICATION_TITLE)
-        val notificationBody = intent?.extras?.getString(Constants.PUSH_NOTIFICATION_BODY)
-        notificationTitle?.let {
-            showPushNotification(it, notificationBody.orEmpty())
-        }
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/main/MainActivity.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/main/MainActivity.kt
@@ -14,6 +14,7 @@ import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.app_bar_main.*
 import org.koin.android.viewmodel.ext.android.viewModel
 import ro.code4.monitorizarevot.R
+import ro.code4.monitorizarevot.helper.Constants
 import ro.code4.monitorizarevot.helper.callSupportCenter
 import ro.code4.monitorizarevot.helper.changePollingStation
 import ro.code4.monitorizarevot.helper.startActivityWithoutTrace
@@ -81,6 +82,12 @@ class MainActivity : BaseActivity<MainViewModel>() {
         viewModel.onLogoutLiveData().observe(this, Observer {
             startActivityWithoutTrace(LoginActivity::class.java)
         })
+
+        val notificationTitle = intent?.extras?.getString(Constants.PUSH_NOTIFICATION_TITLE)
+        val notificationBody = intent?.extras?.getString(Constants.PUSH_NOTIFICATION_BODY)
+        notificationTitle?.let {
+            showPushNotification(it, notificationBody.orEmpty())
+        }
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,11 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0-beta01'
+        classpath 'com.android.tools.build:gradle:3.6.0-beta04'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.1.0'
-        classpath 'com.google.gms:google-services:4.3.2'
-        classpath 'io.fabric.tools:gradle:1.31.0'
+        classpath 'com.google.gms:google-services:4.3.3'
+        classpath 'io.fabric.tools:gradle:1.31.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
### What does it fix?

Closes #160 

This is the simplest implementation. 

Notification is handled from the intent received by the LAUNCHER activity.

In order for the notification to be shown, there should be an update on the Server side to include a data when constructing the firebase push notification. This is how notification body should look:

```javascript
{
 "to" : "...",
 "collapse_key" : "type_a",
 "notification" : {
     "title" : "Title of Your Notification",
     "body" : "Body of Your Notification"
     
 },
 "data" : {
     "notification_title" : "Title of Your Notification",
     "notification_body": "Body of Your Notification"
 }
}
```
So a new **data** object should be created containing **notification_title** and **notification_body** set accordingly

### How has it been tested?

I've tested sending push notifications using FCM endpoint: [https://fcm.googleapis.com/fcm/send](url)

### Possible problems
Because the Launcher activity of the app is **SplashScreenActivity**, that works as a router activity, I've forwarded the notifications only to **MainActivity**.

Also, based on the **SplashScreenActivity** and **MainActivity** launch mode, clicking on the notification will alway open a "fresh" started app, even if you have the app in background and navigated to a different page/fragment - let me know if we want a different scenario here.
