### PR TITLE
Ignore lockOrientation for activities

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,16 +50,19 @@
             android:launchMode="singleTop"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar"
-            android:windowSoftInputMode="adjustPan" />
+            android:windowSoftInputMode="adjustPan"
+                tools:ignore="LockedOrientationActivity" />
         <activity
             android:name=".ui.section.PollingStationActivity"
             android:screenOrientation="portrait"
             android:launchMode="singleTop"
-            android:theme="@style/AppTheme.NoActionBar" />
+            android:theme="@style/AppTheme.NoActionBar"
+                tools:ignore="LockedOrientationActivity" />
         <activity
             android:name=".ui.onboarding.OnboardingActivity"
             android:screenOrientation="portrait"
-            android:theme="@style/AppTheme.Onboarding" />
+            android:theme="@style/AppTheme.Onboarding"
+                tools:ignore="LockedOrientationActivity" />
         <activity
             android:name=".ui.splashscreen.SplashScreenActivity"
             android:label="@string/app_name"


### PR DESCRIPTION
### What does it fix?

Add Ignore LockOrientation to activities to avoid Lint warning in Android manifest.

### How has it been tested?

No test needed.
