### PR TITLE
Add analytics to about screen

### DIFF
--- a/app/src/main/java/ro/code4/monitorizarevot/analytics/Event.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/analytics/Event.kt
@@ -1,0 +1,14 @@
+package ro.code4.monitorizarevot.analytics
+
+enum class Event {
+    SCREEN_OPEN,
+    BUTTON_CLICK,
+    MANUAL_SYNC
+}
+
+enum class ParamKey {
+    NAME,
+    NUMBER_NOT_SYNCED
+}
+
+data class Param(val key: ParamKey, val value: Any)

--- a/app/src/main/java/ro/code4/monitorizarevot/helper/LogUtils.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/helper/LogUtils.kt
@@ -1,0 +1,29 @@
+package ro.code4.monitorizarevot.helper
+
+import android.util.Log
+
+/**
+ * Utility class to easier use the [Log] class in Kotlin files
+ * It takes by default the classes' canonical name or uses [StringUtils.EMPTY],
+ * if the class is null or it is used outside of a class
+ *
+ * @author Sebastian Gansca on 24.11.2019
+ */
+fun Any.logV(message: String, tag: String? = null) = Log.v(buildTag(this::class.java.name, tag), message)
+
+fun Any.logD(message: String, tag: String? = null) = Log.d(buildTag(this::class.java.name, tag), message)
+
+fun Any.logI(message: String, tag: String? = null) = Log.i(buildTag(this::class.java.name, tag), message)
+
+fun Any.logW(message: String, tag: String? = null) = Log.w(buildTag(this::class.java.name, tag), message)
+
+fun Any.logW(message: String, error: Throwable, tag: String? = null) = Log.w(buildTag(this::class.java.name, tag), message, error)
+
+fun Any.logE(message: String, tag: String? = null) = Log.e(buildTag(this::class.java.name, tag), message)
+
+fun Any.logE(message: String, error: Throwable, tag: String? = null) = Log.e(buildTag(this::class.java.name, tag), message, error)
+
+private fun buildTag(className: String?, tag: String?): String = when {
+    !className.isNullOrEmpty() -> className!!
+    else -> tag ?: "ro.code4.monitorizarevot.default"
+}

--- a/app/src/main/java/ro/code4/monitorizarevot/repositories/Repository.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/repositories/Repository.kt
@@ -50,6 +50,7 @@ class Repository : KoinComponent {
 
     private var syncInProgress = false
     fun login(user: User): Observable<LoginResponse> = loginInterface.login(user)
+
     fun registerForNotification(token: String): Observable<ResponseBody> =
         loginInterface.registerForNotification(token)
 

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/base/BaseAnalyticsFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/base/BaseAnalyticsFragment.kt
@@ -1,14 +1,27 @@
 package ro.code4.monitorizarevot.ui.base
 
 import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
 import com.google.firebase.analytics.FirebaseAnalytics
 import org.koin.android.ext.android.inject
-import ro.code4.monitorizarevot.R
+import ro.code4.monitorizarevot.analytics.Event
+import ro.code4.monitorizarevot.analytics.Param
+import ro.code4.monitorizarevot.analytics.ParamKey
+import ro.code4.monitorizarevot.helper.logW
 import ro.code4.monitorizarevot.interfaces.AnalyticsScreenName
 
-abstract class BaseAnalyticsFragment<out T : BaseViewModel> : BaseFragment<T>(), AnalyticsScreenName {
+abstract class BaseAnalyticsFragment : Fragment(), AnalyticsScreenName {
 
     private val firebaseAnalytics: FirebaseAnalytics by inject()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        logAnalyticsEvent(
+            Event.SCREEN_OPEN,
+            Param(ParamKey.NAME, this.javaClass.simpleName))
+    }
 
     override fun onResume() {
         super.onResume()
@@ -16,7 +29,15 @@ abstract class BaseAnalyticsFragment<out T : BaseViewModel> : BaseFragment<T>(),
         firebaseAnalytics.setCurrentScreen(activity!!, getString(screenName), null)
     }
 
-    fun logAnalyticsEvent(event: String, eventData: Bundle) {
-        firebaseAnalytics.logEvent(event, eventData)
+    fun logAnalyticsEvent(event: Event, vararg params: Param) {
+        val bundle = Bundle()
+        for ((k, v) in params ) {
+            when (v) {
+                is String -> bundle.putString(k.name, v)
+                is Int -> bundle.putInt(k.name, v)
+                else -> logW("Not implemented bundle params for ${v.javaClass}")
+            }
+        }
+        firebaseAnalytics.logEvent(event.name, bundle)
     }
 }

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/base/BaseAnalyticsFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/base/BaseAnalyticsFragment.kt
@@ -8,6 +8,7 @@ import org.koin.android.ext.android.inject
 import ro.code4.monitorizarevot.analytics.Event
 import ro.code4.monitorizarevot.analytics.Param
 import ro.code4.monitorizarevot.analytics.ParamKey
+import ro.code4.monitorizarevot.helper.logD
 import ro.code4.monitorizarevot.helper.logW
 import ro.code4.monitorizarevot.interfaces.AnalyticsScreenName
 
@@ -30,6 +31,7 @@ abstract class BaseAnalyticsFragment : Fragment(), AnalyticsScreenName {
     }
 
     fun logAnalyticsEvent(event: Event, vararg params: Param) {
+        logD("logAnalyticsEvent: ${event.name}")
         val bundle = Bundle()
         for ((k, v) in params ) {
             when (v) {

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/base/ViewModelFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/base/ViewModelFragment.kt
@@ -1,18 +1,14 @@
 package ro.code4.monitorizarevot.ui.base
 
 import android.content.Context
-import android.net.ConnectivityManager
-import android.net.NetworkCapabilities
-import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import ro.code4.monitorizarevot.interfaces.Layout
 import ro.code4.monitorizarevot.interfaces.ViewModelSetter
 
-abstract class BaseFragment<out T : BaseViewModel> : Fragment(), Layout,
+abstract class ViewModelFragment<out T : BaseViewModel> : BaseAnalyticsFragment(), Layout,
     ViewModelSetter<T> {
     lateinit var mContext: Context
 

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/forms/FormsFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/forms/FormsFragment.kt
@@ -13,13 +13,15 @@ import ro.code4.monitorizarevot.helper.Constants.FORM
 import ro.code4.monitorizarevot.helper.Constants.QUESTION
 import ro.code4.monitorizarevot.helper.changePollingStation
 import ro.code4.monitorizarevot.helper.replaceFragment
-import ro.code4.monitorizarevot.ui.base.BaseFragment
+import ro.code4.monitorizarevot.ui.base.ViewModelFragment
 import ro.code4.monitorizarevot.ui.forms.questions.QuestionsDetailsFragment
 import ro.code4.monitorizarevot.ui.forms.questions.QuestionsListFragment
 import ro.code4.monitorizarevot.ui.main.MainActivity
 import ro.code4.monitorizarevot.ui.notes.NoteFragment
 
-class FormsFragment : BaseFragment<FormsViewModel>() {
+class FormsFragment : ViewModelFragment<FormsViewModel>() {
+    override val screenName: Int
+        get() = R.string.menu_forms
 
     override val layout: Int
         get() = R.layout.fragment_main

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/forms/FormsListFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/forms/FormsListFragment.kt
@@ -7,17 +7,19 @@ import android.view.View
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
-import com.google.firebase.analytics.FirebaseAnalytics
 import com.yqritc.recyclerviewflexibledivider.HorizontalDividerItemDecoration
 import kotlinx.android.synthetic.main.fragment_forms.*
 import org.koin.android.viewmodel.ext.android.getSharedViewModel
 import ro.code4.monitorizarevot.R
 import ro.code4.monitorizarevot.adapters.FormDelegationAdapter
+import ro.code4.monitorizarevot.analytics.Event
+import ro.code4.monitorizarevot.analytics.Param
+import ro.code4.monitorizarevot.analytics.ParamKey
 import ro.code4.monitorizarevot.helper.isOnline
-import ro.code4.monitorizarevot.ui.base.BaseAnalyticsFragment
+import ro.code4.monitorizarevot.ui.base.ViewModelFragment
 
 
-class FormsListFragment : BaseAnalyticsFragment<FormsViewModel>() {
+class FormsListFragment : ViewModelFragment<FormsViewModel>() {
 
     companion object {
         val TAG = FormsListFragment::class.java.simpleName
@@ -55,7 +57,7 @@ class FormsListFragment : BaseAnalyticsFragment<FormsViewModel>() {
 
         syncButton.setOnClickListener {
             // TODO send number of unsynced items
-            logSyncManuallyEvent(0)
+            logAnalyticsEvent(Event.MANUAL_SYNC, Param(ParamKey.NUMBER_NOT_SYNCED, 0))
 
             if (!mContext.isOnline()) {
                 Snackbar.make(syncButton, getString(R.string.form_sync_no_internet), Snackbar.LENGTH_SHORT)
@@ -75,13 +77,5 @@ class FormsListFragment : BaseAnalyticsFragment<FormsViewModel>() {
                     .sizeResId(R.dimen.small_margin).build()
             )
         }
-    }
-
-    private fun logSyncManuallyEvent(numberOfNotSynced: Int) {
-        val bundle = Bundle()
-        bundle.putString(FirebaseAnalytics.Param.ITEM_NAME, getString(R.string.analytics_event_manual_sync))
-        bundle.putInt(FirebaseAnalytics.Param.VALUE, numberOfNotSynced)
-
-        logAnalyticsEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle)
     }
 }

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/forms/questions/QuestionsDetailsFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/forms/questions/QuestionsDetailsFragment.kt
@@ -21,11 +21,11 @@ import ro.code4.monitorizarevot.data.model.Question
 import ro.code4.monitorizarevot.helper.Constants
 import ro.code4.monitorizarevot.helper.addOnLayoutChangeListenerForGalleryEffect
 import ro.code4.monitorizarevot.helper.addOnScrollListenerForGalleryEffect
-import ro.code4.monitorizarevot.ui.base.BaseAnalyticsFragment
+import ro.code4.monitorizarevot.ui.base.ViewModelFragment
 import ro.code4.monitorizarevot.ui.forms.FormsViewModel
 
 
-class QuestionsDetailsFragment : BaseAnalyticsFragment<QuestionsDetailsViewModel>(),
+class QuestionsDetailsFragment : ViewModelFragment<QuestionsDetailsViewModel>(),
     QuestionDetailsAdapter.OnClickListener {
     override fun addNoteFor(question: Question) {
         baseViewModel.selectedNotes(question)

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/forms/questions/QuestionsListFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/forms/questions/QuestionsListFragment.kt
@@ -15,11 +15,10 @@ import ro.code4.monitorizarevot.R
 import ro.code4.monitorizarevot.adapters.QuestionDelegationAdapter
 import ro.code4.monitorizarevot.data.model.FormDetails
 import ro.code4.monitorizarevot.helper.Constants.FORM
-import ro.code4.monitorizarevot.ui.base.BaseAnalyticsFragment
-import ro.code4.monitorizarevot.ui.base.BaseFragment
+import ro.code4.monitorizarevot.ui.base.ViewModelFragment
 import ro.code4.monitorizarevot.ui.forms.FormsViewModel
 
-class QuestionsListFragment : BaseAnalyticsFragment<QuestionsViewModel>() {
+class QuestionsListFragment : ViewModelFragment<QuestionsViewModel>() {
 
     override val layout: Int
         get() = R.layout.fragment_list

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/guide/GuideFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/guide/GuideFragment.kt
@@ -9,9 +9,10 @@ import org.koin.android.ext.android.inject
 import ro.code4.monitorizarevot.R
 import ro.code4.monitorizarevot.helper.WebClient
 import ro.code4.monitorizarevot.ui.base.BaseAnalyticsFragment
+import ro.code4.monitorizarevot.ui.base.ViewModelFragment
 import ro.code4.monitorizarevot.widget.ProgressDialogFragment
 
-class GuideFragment : BaseAnalyticsFragment<GuideViewModel>(), WebClient.WebLoaderListener {
+class GuideFragment : ViewModelFragment<GuideViewModel>(), WebClient.WebLoaderListener {
 
 
     override val layout: Int

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/login/LoginViewModel.kt
@@ -1,6 +1,7 @@
 package ro.code4.monitorizarevot.ui.login
 
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.lifecycle.LiveData
 import com.google.firebase.iid.FirebaseInstanceId
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -9,10 +10,7 @@ import org.koin.core.inject
 import ro.code4.monitorizarevot.BuildConfig
 import ro.code4.monitorizarevot.data.model.User
 import ro.code4.monitorizarevot.data.model.response.LoginResponse
-import ro.code4.monitorizarevot.helper.Result
-import ro.code4.monitorizarevot.helper.SingleLiveEvent
-import ro.code4.monitorizarevot.helper.hasCompletedOnboarding
-import ro.code4.monitorizarevot.helper.saveToken
+import ro.code4.monitorizarevot.helper.*
 import ro.code4.monitorizarevot.repositories.Repository
 import ro.code4.monitorizarevot.ui.base.BaseViewModel
 import ro.code4.monitorizarevot.ui.onboarding.OnboardingActivity
@@ -33,11 +31,13 @@ class LoginViewModel : BaseViewModel() {
     }
 
     private fun onSuccessfulLogin(loginResponse: LoginResponse, firebaseToken: String) {
+        logD("onSuccessfulLogin")
         sharedPreferences.saveToken(loginResponse.accessToken)
         registerForNotification(firebaseToken)
     }
 
     private fun onSuccessfulRegisteredForNotification() {
+        logD("onSuccessfulRegisteredForNotification")
         if (sharedPreferences.hasCompletedOnboarding()) {
             loginLiveData.postValue(Result.Success(PollingStationActivity::class.java))
         } else {
@@ -66,6 +66,7 @@ class LoginViewModel : BaseViewModel() {
     }
 
     fun login(phone: String, password: String, firebaseToken: String) {
+        logD("login: $phone : $password -> $firebaseToken")
         disposables.add(
             loginRepository.login(User(phone, password, firebaseToken))
                 .subscribeOn(Schedulers.io())
@@ -77,6 +78,7 @@ class LoginViewModel : BaseViewModel() {
     }
 
     private fun registerForNotification(firebaseToken: String) {
+        logD("registerForNotification with $firebaseToken")
         disposables.add(
             loginRepository.registerForNotification(firebaseToken)
                 .subscribeOn(Schedulers.io())
@@ -86,6 +88,7 @@ class LoginViewModel : BaseViewModel() {
     }
 
     override fun onError(throwable: Throwable) {
+        logE("onError ${throwable.message}", throwable)
         loginLiveData.postValue(Result.Failure(throwable))
     }
 }

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/notes/NoteFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/notes/NoteFragment.kt
@@ -34,9 +34,10 @@ import ro.code4.monitorizarevot.helper.Constants.REQUEST_CODE_GALLERY
 import ro.code4.monitorizarevot.helper.Constants.REQUEST_CODE_RECORD_VIDEO
 import ro.code4.monitorizarevot.helper.Constants.REQUEST_CODE_TAKE_PHOTO
 import ro.code4.monitorizarevot.ui.base.BaseAnalyticsFragment
+import ro.code4.monitorizarevot.ui.base.ViewModelFragment
 import ro.code4.monitorizarevot.ui.forms.FormsViewModel
 
-class NoteFragment : BaseAnalyticsFragment<NoteViewModel>(), PermissionManager.PermissionListener {
+class NoteFragment : ViewModelFragment<NoteViewModel>(), PermissionManager.PermissionListener {
 
     override val layout: Int
         get() = R.layout.fragment_note

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/section/details/PollingStationDetailsFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/section/details/PollingStationDetailsFragment.kt
@@ -11,13 +11,12 @@ import kotlinx.android.synthetic.main.fragment_polling_station_selection.continu
 import kotlinx.android.synthetic.main.widget_change_polling_station_bar.*
 import org.koin.android.viewmodel.ext.android.getSharedViewModel
 import ro.code4.monitorizarevot.R
-import ro.code4.monitorizarevot.ui.base.BaseAnalyticsFragment
-import ro.code4.monitorizarevot.ui.base.BaseFragment
+import ro.code4.monitorizarevot.ui.base.ViewModelFragment
 import ro.code4.monitorizarevot.ui.section.PollingStationViewModel
 import java.util.*
 
 
-class PollingStationDetailsFragment : BaseAnalyticsFragment<PollingStationViewModel>() {
+class PollingStationDetailsFragment : ViewModelFragment<PollingStationViewModel>() {
 
     companion object {
         val TAG = PollingStationDetailsFragment::class.java.simpleName

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/section/selection/PollingStationSelectionFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/section/selection/PollingStationSelectionFragment.kt
@@ -11,11 +11,12 @@ import org.koin.android.viewmodel.ext.android.getSharedViewModel
 import org.koin.android.viewmodel.ext.android.viewModel
 import ro.code4.monitorizarevot.R
 import ro.code4.monitorizarevot.ui.base.BaseAnalyticsFragment
+import ro.code4.monitorizarevot.ui.base.ViewModelFragment
 import ro.code4.monitorizarevot.ui.section.PollingStationViewModel
 import ro.code4.monitorizarevot.widget.ProgressDialogFragment
 
 
-class PollingStationSelectionFragment : BaseAnalyticsFragment<PollingStationSelectionViewModel>() {
+class PollingStationSelectionFragment : ViewModelFragment<PollingStationSelectionViewModel>() {
 
     private val progressDialog: ProgressDialogFragment by lazy {
         ProgressDialogFragment().also {

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/settings/AboutFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/settings/AboutFragment.kt
@@ -7,14 +7,20 @@ import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import kotlinx.android.synthetic.main.fragment_about.*
 import ro.code4.monitorizarevot.BuildConfig
 import ro.code4.monitorizarevot.R
+import ro.code4.monitorizarevot.analytics.Event
+import ro.code4.monitorizarevot.analytics.Param
+import ro.code4.monitorizarevot.analytics.ParamKey
 import ro.code4.monitorizarevot.helper.browse
+import ro.code4.monitorizarevot.helper.logW
 import ro.code4.monitorizarevot.helper.toHtml
+import ro.code4.monitorizarevot.ui.base.BaseAnalyticsFragment
 
-class AboutFragment : Fragment() {
+class AboutFragment : BaseAnalyticsFragment() {
+    override val screenName: Int
+        get() = R.string.menu_about
 
     companion object {
         val TAG = AboutFragment::class.java.simpleName
@@ -36,16 +42,20 @@ class AboutFragment : Fragment() {
         content.text = getString(R.string.about_content).toHtml()
         content.movementMethod = LinkMovementMethod.getInstance()
 
-        optionChangeLanguage.setOnClickListener {
-            //TODO
-        }
+        optionChangeLanguage.setOnClickListener { onChangeLanguageClicked(view) }
 
-        optionContact.setOnClickListener { onContactClicked() }
+        optionContact.setOnClickListener { onContactClicked(view) }
 
-        optionViewPolicy.setOnClickListener { context?.browse(BuildConfig.PRIVACY_WEB_URL) }
+        optionViewPolicy.setOnClickListener { onViewPolicyClicked(view) }
     }
 
-    private fun onContactClicked() {
+    private fun onChangeLanguageClicked(view: View) {
+        logClickEvent(view)
+        // TODO: Implement
+    }
+
+    private fun onContactClicked(view: View) {
+        logClickEvent(view)
         val emailIntent = Intent(
             Intent.ACTION_SENDTO,
             Uri.fromParts("mailto", BuildConfig.SUPPORT_EMAIL, null)
@@ -58,4 +68,18 @@ class AboutFragment : Fragment() {
         )
     }
 
+    private fun onViewPolicyClicked(view: View) {
+        logClickEvent(view)
+        val result = context?.browse(BuildConfig.PRIVACY_WEB_URL)
+        if (!result!!) {
+            logW("No app to view " + BuildConfig.PRIVACY_WEB_URL)
+        }
+    }
+
+    private fun logClickEvent(view: View) {
+        logAnalyticsEvent(
+            Event.BUTTON_CLICK,
+            Param(ParamKey.NAME, resources.getResourceEntryName(view.id))
+        )
+    }
 }


### PR DESCRIPTION
### What does it fix?

Closes #169 

Changes Fragments inheritance structure to:
- {SpecificFragment without ViewModel} <- BaseAnalyticsFragment <- Fragment
- {SpecificFragment with ViewModel} <- ViewModelFragment <- BaseAnalyticsFragment <- <- Fragment

**BaseAnalyticsFragment** 
- Reports it's open (onViewCreated) event
- Implements logAnalyticsEvent for easier reporting

Added Event and ParamKey enums to standardize the events reporting and avoid hardcoded strings.

Please review if the new structure for Firebase event params from bundle are acceptable.

### How has it been tested?

This wasn't tested E2E as I do not have yet access to Firebase project. 

Please review the new fragments inheritance structure and let me know if it is ok since I do not know the whole project architecture but this seems as a better approach to me. 

This PR includes also log changes from PR https://github.com/code4romania/mon-vot-android-kotlin/pull/181
