### PR TITLE
Fix analytics bug in AboutFragment

### DIFF
--- a/app/src/main/java/ro/code4/monitorizarevot/ui/settings/AboutFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/settings/AboutFragment.kt
@@ -42,11 +42,11 @@ class AboutFragment : BaseAnalyticsFragment() {
         content.text = getString(R.string.about_content).toHtml()
         content.movementMethod = LinkMovementMethod.getInstance()
 
-        optionChangeLanguage.setOnClickListener { onChangeLanguageClicked(view) }
+        optionChangeLanguage.setOnClickListener { onChangeLanguageClicked(it) }
 
-        optionContact.setOnClickListener { onContactClicked(view) }
+        optionContact.setOnClickListener { onContactClicked(it) }
 
-        optionViewPolicy.setOnClickListener { onViewPolicyClicked(view) }
+        optionViewPolicy.setOnClickListener { onViewPolicyClicked(it) }
     }
 
     private fun onChangeLanguageClicked(view: View) {


### PR DESCRIPTION
There is a bug in the code related to analytics of AboutFragment. At the moment, if the user selects any of the three possible options there the app would crash because it tries to reference wrong views. I made the changes to use the proper views there.