### PR TITLE
Copy files to cache instead of using directly. Fixes #178

### DIFF
--- a/app/src/main/java/ro/code4/monitorizarevot/helper/FileUtils.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/helper/FileUtils.kt
@@ -1,165 +1,62 @@
 package ro.code4.monitorizarevot.helper
 
-import android.content.ContentUris
+import android.content.ContentResolver
 import android.content.Context
-import android.database.Cursor
-import android.database.DatabaseUtils
 import android.net.Uri
-import android.provider.DocumentsContract
-import android.provider.MediaStore
-import android.util.Log
+import android.provider.OpenableColumns
+import android.webkit.MimeTypeMap
+import java.io.File
+import java.io.IOException
 
 
 /**
- * File utilities, thanks to https://github.com/epforgpl/monitorizare-vot-android/
+ * File utilities
  */
 object FileUtils {
-    /** TAG for log messages.  */
-    internal const val TAG = "FileUtils"
-    private const val DEBUG = false // Set to true to enable logging
+    private const val UPLOADS_DIR_NAME = "uploads"
 
-    /**
-     * Get the value of the data column for this Uri. This is useful for
-     * MediaStore Uris, and other file-based ContentProviders.
-     *
-     * @param context The context.
-     * @param uri The Uri to query.
-     * @param selection (Optional) Filter used in the query.
-     * @param selectionArgs (Optional) Selection arguments used in the query.
-     * @return The value of the _data column, which is typically a file path.
-     * @author paulburke
-     */
-    fun getDataColumn(
-        context: Context, uri: Uri?, selection: String?,
-        selectionArgs: Array<String>?
-    ): String? {
-
-        var cursor: Cursor? = null
-        val column = "_data"
-        val projection = arrayOf(column)
-        uri?.let {
-            try {
-                cursor =
-                    context.contentResolver.query(it, projection, selection, selectionArgs, null)
-                cursor?.let { curs ->
-                    @Suppress("ConstantConditionIf")
-                    if (curs.moveToFirst()) {
-                        if (DEBUG)
-                            DatabaseUtils.dumpCursor(curs)
-
-                        val columnIndex = curs.getColumnIndexOrThrow(column)
-                        return curs.getString(columnIndex)
-                    }
+    @Throws(IOException::class)
+    internal fun copyFileToCache(context: Context, uri: Uri): File =
+        with(context) {
+            val directory = File(cacheDir, UPLOADS_DIR_NAME)
+            directory.mkdirs()
+            File(
+                directory,
+                getFileName(uri) ?: generateTempFileName(uri)
+            ).also { f ->
+                contentResolver.openInputStream(uri)?.use {
+                    f.createNewFile()
+                    it.copyTo(f.outputStream())
                 }
-            } finally {
-                cursor?.close()
             }
         }
-        return null
-    }
 
-    /**
-     * Get a file path from a Uri. This will get the the path for Storage Access
-     * Framework Documents, as well as the _data field for the MediaStore and
-     * other file-based ContentProviders.<br></br>
-     * <br></br>
-     * Callers should check whether the path is local before assuming it
-     * represents a local file.
-     *
-     */
-    fun getPath(context: Context, uri: Uri): String? {
+    private fun Context.getFileName(uri: Uri): String? =
+        when (uri.scheme) {
+            ContentResolver.SCHEME_FILE -> uri.path?.let { File(it).name }
+            ContentResolver.SCHEME_CONTENT -> getCursorContent(uri)
+            else -> null
+        }
 
-        @Suppress("ConstantConditionIf")
-        if (DEBUG)
-            Log.d(
-                "$TAG File -",
-                "Authority: " + uri.authority +
-                        ", Fragment: " + uri.fragment +
-                        ", Port: " + uri.port +
-                        ", Query: " + uri.query +
-                        ", Scheme: " + uri.scheme +
-                        ", Host: " + uri.host +
-                        ", Segments: " + uri.pathSegments.toString()
-            )
+    private fun Context.getCursorContent(uri: Uri): String? =
+        runCatching {
+            contentResolver.query(uri, null, null, null, null)
+                ?.let { cursor ->
+                    cursor.run {
+                        if (moveToFirst())
+                            getString(getColumnIndex(OpenableColumns.DISPLAY_NAME))
+                        else null
+                    }.also { cursor.close() }
+                }
+        }.getOrNull()
 
-        // DocumentProvider
-        if (isExternalStorageDocument(uri)) {
-            val docId = DocumentsContract.getDocumentId(uri)
-            val split =
-                docId.split((":").toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-            val type = split[0]
+    private fun Context.generateTempFileName(uri: Uri): String =
+        "mon_vot_${System.currentTimeMillis()}.${getMimeType(contentResolver, uri)}"
 
-            if ("primary".equals(type, ignoreCase = true)) {
-                return "${context.getExternalFilesDir(null)}/${split[1]}"
-            }
-
-            // TODO handle non-primary volumes
-        } else if (isDownloadsDocument(uri)) {
-
-            val id = DocumentsContract.getDocumentId(uri)
-            val contentUri = ContentUris.withAppendedId(
-                Uri.parse("content://downloads/public_downloads"), java.lang.Long.valueOf(id)
-            )
-
-            return getDataColumn(context, contentUri, null, null)
-        } else if (isMediaDocument(uri)) {
-            val docId = DocumentsContract.getDocumentId(uri)
-            val split =
-                docId.split((":").toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-            val type = split[0]
-
-            var contentUri: Uri? = null
-            @Suppress("ConstantConditionIf")
-            when (type) {
-                "image" -> contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
-                "video" -> contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI
-                "audio" -> contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
-            }
-
-            val selection = "_id=?"
-            val selectionArgs = arrayOf(split[1])
-
-            return getDataColumn(context, contentUri, selection, selectionArgs)
-        }// MediaProvider
-        // DownloadsProvider
-        // File
-        // MediaStore (and general)
-
-        return null
-    }
-
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is DownloadsProvider.
-     * @author paulburke
-     */
-    fun isDownloadsDocument(uri: Uri): Boolean {
-        return "com.android.providers.downloads.documents" == uri.authority
-    }
-
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is ExternalStorageProvider.
-     * @author paulburke
-     */
-    fun isExternalStorageDocument(uri: Uri): Boolean {
-        return "com.android.externalstorage.documents" == uri.authority
-    }
-
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is Google Photos.
-     */
-    fun isGooglePhotosUri(uri: Uri): Boolean {
-        return "com.google.android.apps.photos.content" == uri.authority
-    }
-
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is MediaProvider.
-     * @author paulburke
-     */
-    fun isMediaDocument(uri: Uri): Boolean {
-        return "com.android.providers.media.documents" == uri.authority
-    }
+    private fun getMimeType(contentResolver: ContentResolver, uri: Uri): String? =
+        if (uri.scheme == ContentResolver.SCHEME_CONTENT) {
+            MimeTypeMap.getSingleton().getExtensionFromMimeType(contentResolver.getType(uri))
+        } else {
+            MimeTypeMap.getFileExtensionFromUrl(uri.toString())
+        }
 }

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/notes/NoteViewModel.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/notes/NoteViewModel.kt
@@ -72,7 +72,6 @@ class NoteViewModel : BaseFormViewModel() {
         repository.saveNote(note)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
-            .doOnComplete { noteFile?.delete() }
             .subscribe(
                 {},
                 {


### PR DESCRIPTION
Get InputStream for Uri and write its content to the cache folder instead of trying to get the file.

Checked on Uri's:
```
content://com.android.providers.media.documents/document/image%3A1017 (Images)
content://com.android.providers.downloads.documents/document/msf%3A1019 (Downloads)
content://com.google.android.apps.docs.storage/document/acc%3D1%3Bdoc%3Dencoded%3DI35Uf5ygTirRhYv9I9zj96uxAsRmXJ5TIy1FrpWs7F%2Fa0pH8BNFolg%3D%3D (Google Drive)
content://com.google.android.apps.photos.contentprovider/-1/1/content%3A%2F%2Fmedia%2Fexternal%2Fimages%2Fmedia%2F317/ORIGINAL/NONE/image%2Fjpeg/1932874955 (Google Photo)
```