### PR TITLE
Fix sorting for forms

### DIFF
--- a/app/src/main/java/ro/code4/monitorizarevot/ui/forms/FormsViewModel.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/forms/FormsViewModel.kt
@@ -112,13 +112,13 @@ class FormsViewModel : BaseFormViewModel() {
         } catch (e: Exception) {
             false
         }
-        val formsList = when {
+        var formsList = when {
             !filterDiasporaForms || pollingStationLiveData.value?.isDiaspora == true -> forms.map {
                 FormListItem(it)
             }
             else -> forms.filter { it.form.diaspora == false }.map { FormListItem(it) }
         }
-        formsList.sortedBy { it.formWithSections.form.order }
+        formsList = formsList.sortedBy { it.formWithSections.form.order }
         items.addAll(formsList)
         items.add(AddNoteListItem())
         formsLiveData.postValue(items)


### PR DESCRIPTION
### What does it fix?
Fixes a bug with sorting forms based on the order field. The method sortedBy() returns the list sorted, it doesn't sort the list in place(like sortBy() does on a mutable list).