### PR TITLE
Use filesDir instead of cacheDir

### DIFF
--- a/app/src/main/java/ro/code4/monitorizarevot/helper/FileUtils.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/helper/FileUtils.kt
@@ -18,7 +18,7 @@ object FileUtils {
     @Throws(IOException::class)
     internal fun copyFileToCache(context: Context, uri: Uri): File =
         with(context) {
-            val directory = File(cacheDir, UPLOADS_DIR_NAME)
+            val directory = File(filesDir, UPLOADS_DIR_NAME)
             directory.mkdirs()
             File(
                 directory,


### PR DESCRIPTION
This PR changes the directory where the note files will be created. The problem with `cacheDir` is that, as the [documentation](https://developer.android.com/reference/android/content/Context#getCacheDir()) says, it can be cleared by the system(and in other situations as well). If the app's cache will be cleared when we have notes with files which weren't uploaded yet this will cause the app to not be able to upload those notes. When the user will try to sync, the retrofit client in the repository will fail because it expects to upload a file which will not be found on disk.

On the other hand, [`filesDir `](https://developer.android.com/reference/android/content/Context#getFilesDir()) can't be cleared by the system automatically.



