### PR TITLE
Enable upload of multiple files with note

### DIFF
--- a/app/src/main/java/ro/code4/monitorizarevot/helper/Constants.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/helper/Constants.kt
@@ -11,6 +11,7 @@ object Constants {
     const val REQUEST_CODE_RECORD_VIDEO = 1001
     const val REQUEST_CODE_TAKE_PHOTO = 1002
     const val REQUEST_CODE_GALLERY = 1003
+    const val FILES_PATHS_SEPARATOR = "|"
 
     const val TYPE_MULTI_CHOICE = 0
     const val TYPE_SINGLE_CHOICE = 1

--- a/app/src/main/java/ro/code4/monitorizarevot/helper/Utils.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/helper/Utils.kt
@@ -313,6 +313,7 @@ fun Fragment.openGallery() {
     intent.type = "image/*"
     val extraMime = arrayOf("image/*", "video/*")
     intent.putExtra(Intent.EXTRA_MIME_TYPES, extraMime)
+    intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
     intent.addCategory(Intent.CATEGORY_OPENABLE)
     intent.resolveActivity(activity!!.packageManager)?.also {
         startActivityForResult(

--- a/app/src/main/java/ro/code4/monitorizarevot/services/ApiInterface.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/services/ApiInterface.kt
@@ -28,13 +28,12 @@ interface ApiInterface {
     fun postQuestionAnswer(@Body responseAnswer: ResponseAnswerContainer): Observable<ResponseBody>
 
     @Multipart
-    @POST("/api/v2/note/upload")
+    @POST("/api/v2/note")
     fun postNote(
-        @Part file: MultipartBody.Part?,
+        @Part files: Array<MultipartBody.Part>?,
         @Part countyCode: MultipartBody.Part,
         @Part pollingStationNumber: MultipartBody.Part,
         @Part questionId: MultipartBody.Part,
         @Part description: MultipartBody.Part
     ): Observable<ResponseBody>
-
 }

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/notes/NoteFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/notes/NoteFragment.kt
@@ -80,11 +80,11 @@ class NoteFragment : ViewModelFragment<NoteViewModel>(), PermissionManager.Permi
             noteFileContainer.visibility = View.VISIBLE
             noteFileContainer.removeAllViews()
             it.forEach { filename ->
-                val newTexView = requireActivity().layoutInflater.inflate(
+                val newTextView = requireActivity().layoutInflater.inflate(
                     R.layout.include_note_filename, noteFileContainer, false
                 ) as TextView
-                newTexView.text = filename
-                noteFileContainer.addView(newTexView)
+                newTextView.text = filename
+                noteFileContainer.addView(newTextView)
             }
         })
         viewModel.submitCompleted().observe(this, Observer {
@@ -152,7 +152,7 @@ class NoteFragment : ViewModelFragment<NoteViewModel>(), PermissionManager.Permi
                     viewModel.addMediaToGallery()
                 }
                 REQUEST_CODE_GALLERY -> {
-                    viewModel.addMediaFromGallery(data?.data)
+                    viewModel.addMediaFromGallery(data?.clipData, data?.data)
                 }
             }
         }

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/notes/NoteFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/notes/NoteFragment.kt
@@ -14,6 +14,8 @@ import android.provider.Settings
 import android.text.TextWatcher
 import android.view.MotionEvent
 import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.view.menu.MenuPopupHelper
@@ -33,7 +35,6 @@ import ro.code4.monitorizarevot.helper.*
 import ro.code4.monitorizarevot.helper.Constants.REQUEST_CODE_GALLERY
 import ro.code4.monitorizarevot.helper.Constants.REQUEST_CODE_RECORD_VIDEO
 import ro.code4.monitorizarevot.helper.Constants.REQUEST_CODE_TAKE_PHOTO
-import ro.code4.monitorizarevot.ui.base.BaseAnalyticsFragment
 import ro.code4.monitorizarevot.ui.base.ViewModelFragment
 import ro.code4.monitorizarevot.ui.forms.FormsViewModel
 
@@ -59,6 +60,7 @@ class NoteFragment : ViewModelFragment<NoteViewModel>(), PermissionManager.Permi
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val noteFileContainer = view.findViewById<LinearLayout>(R.id.noteFilesContainer)
         notesList.layoutManager = LinearLayoutManager(mContext)
         notesList.adapter = noteAdapter
         notesList.addItemDecoration(
@@ -74,10 +76,16 @@ class NoteFragment : ViewModelFragment<NoteViewModel>(), PermissionManager.Permi
         viewModel.notes().observe(this, Observer {
             noteAdapter.items = it
         })
-        viewModel.fileName().observe(this, Observer {
-            filenameText.text = it
-            filenameText.visibility = View.VISIBLE
-            addMediaButton.visibility = View.GONE
+        viewModel.filesNames().observe(this, Observer {
+            noteFileContainer.visibility = View.VISIBLE
+            noteFileContainer.removeAllViews()
+            it.forEach { filename ->
+                val newTexView = requireActivity().layoutInflater.inflate(
+                    R.layout.include_note_filename, noteFileContainer, false
+                ) as TextView
+                newTexView.text = filename
+                noteFileContainer.addView(newTexView)
+            }
         })
         viewModel.submitCompleted().observe(this, Observer {
             activity?.onBackPressed()
@@ -122,11 +130,11 @@ class NoteFragment : ViewModelFragment<NoteViewModel>(), PermissionManager.Permi
                 R.id.note_gallery -> openGallery()
                 R.id.note_photo -> {
                     val file = takePicture()
-                    viewModel.addFile(file)
+                    viewModel.addUserGeneratedFile(file)
                 }
                 R.id.note_video -> {
                     val file = takeVideo()
-                    viewModel.addFile(file)
+                    viewModel.addUserGeneratedFile(file)
                 }
             }
             true
@@ -144,7 +152,7 @@ class NoteFragment : ViewModelFragment<NoteViewModel>(), PermissionManager.Permi
                     viewModel.addMediaToGallery()
                 }
                 REQUEST_CODE_GALLERY -> {
-                    viewModel.getMediaFromGallery(data?.data)
+                    viewModel.addMediaFromGallery(data?.data)
                 }
             }
         }

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/notes/NoteViewModel.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/notes/NoteViewModel.kt
@@ -118,7 +118,7 @@ class NoteViewModel : BaseFormViewModel() {
             filesNamesLiveData.postValue(noteFiles.map { file -> file.name }.toList())
             if (hasFailedFiles) {
                 messageIdToastLiveData.postValue(
-                    app.getString(R.string.error_permission_external_storage)
+                    app.getString(R.string.error_note_file_copy_multiple)
                 )
             }
         } else if (uri != null) {
@@ -126,7 +126,7 @@ class NoteViewModel : BaseFormViewModel() {
                 noteFiles.add(it)
                 filesNamesLiveData.postValue(noteFiles.map { file -> file.name }.toList())
             } ?: messageIdToastLiveData.postValue(
-                app.getString(R.string.error_permission_external_storage)
+                app.getString(R.string.error_note_file_copy_single)
             )
         }
     }

--- a/app/src/main/res/layout/include_note_filename.xml
+++ b/app/src/main/res/layout/include_note_filename.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/filenameText"
+    style="@style/Text.Small"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/margin"
+    android:drawableStart="@drawable/ic_file"
+    android:drawablePadding="@dimen/small_margin"
+    tools:text="Frauda_0342.jpg" />

--- a/app/src/main/res/layout/layout_edit_note.xml
+++ b/app/src/main/res/layout/layout_edit_note.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     style="@style/MaterialCardView"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -34,32 +33,27 @@
             android:padding="@dimen/medium_margin"
             app:layout_constraintTop_toBottomOf="@id/title" />
 
-        <TextView
-            android:id="@+id/filenameText"
-            style="@style/Text.Small"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:id="@+id/noteFilesContainer"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin"
-            android:drawableStart="@drawable/ic_file"
-            android:drawablePadding="@dimen/small_margin"
+            android:orientation="vertical"
             android:visibility="gone"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/noteInput"
-            tools:text="Frauda_0342.jpg"
-            tools:visibility="visible" />
+            app:layout_constraintTop_toBottomOf="@id/noteInput" />
 
         <Button
             android:id="@+id/addMediaButton"
             style="@style/Button.Text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:icon="@drawable/ic_note_media"
             android:layout_marginTop="@dimen/big_margin"
             android:text="@string/note_media"
+            app:icon="@drawable/ic_note_media"
             app:layout_constraintBottom_toTopOf="@id/submitButton"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/filenameText" />
+            app:layout_constraintTop_toBottomOf="@id/noteFilesContainer" />
 
         <Button
             android:id="@+id/submitButton"

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -113,7 +113,8 @@
     <string name="note_description_hint">Scrie aici</string>
     <string name="note_media">Adaugă foto/video</string>
     <string name="invalid_note">Introdu o descriere sau alege un fişier</string>
-    <string name="error_permission_external_storage">Permisiunea este necesară pentru a putea selecta o resursă</string>
+    <string name="error_note_file_copy_single">Nu am putut atașa fișierul. Verificați permisiunile aplicației și spațiul de stocare disponibil</string>
+    <string name="error_note_file_copy_multiple">Unele fișiere nu au putut fi atașate. Verificați permisiunile aplicației și spațiul de stocare disponibil</string>
     <string name="note_gallery">Încarcă din galerie</string>
     <string name="note_photo">Fotografiază</string>
     <string name="note_video">Înregistrează video</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -113,7 +113,7 @@
     <string name="note_description_hint">Scrie aici</string>
     <string name="note_media">Adaugă foto/video</string>
     <string name="invalid_note">Introdu o descriere sau alege un fişier</string>
-    <string name="error_note_file_copy_single">Nu am putut atașa fișierul. Verificați permisiunile aplicației și spațiul de stocare disponibil</string>
+    <string name="error_note_file_copy_single">Fișierul nu a putut fi atașat. Verificați permisiunile aplicației și spațiul de stocare disponibil</string>
     <string name="error_note_file_copy_multiple">Unele fișiere nu au putut fi atașate. Verificați permisiunile aplicației și spațiul de stocare disponibil</string>
     <string name="note_gallery">Încarcă din galerie</string>
     <string name="note_photo">Fotografiază</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,7 +113,8 @@
     <string name="note_description_hint">Type here</string>
     <string name="note_media">Add photo or video</string>
     <string name="invalid_note">Add a description or choose a file</string>
-    <string name="error_permission_external_storage">We need your permission to select a resource</string>
+    <string name="error_note_file_copy_single">Unable to attach the file. Check the app permissions and the storage space available</string>
+    <string name="error_note_file_copy_multiple">Unable to attach some of the files. Check the app permissions and the storage space available</string>
     <string name="note_gallery">Load from gallery</string>
     <string name="note_photo">Take photo</string>
     <string name="note_video">Record video</string>


### PR DESCRIPTION
### What does it fix?

Closes #28 

To allow the user to add multiple files to a note I kept the add media button always visible. To keep the changes to a minimum I reused the old logic, so instead of the string in the Note class referencing a single path it will represent a concatenation of all the paths to be uploaded with the note. The repository can then extract the paths and make the backend request.

### How has it been tested?

I tested the changes manually on various API levels. I plan to add some tests at a later point after some code refactoring.