### PR TITLE
Add sync related UI changes

### DIFF
--- a/app/src/main/java/ro/code4/monitorizarevot/ui/forms/FormsListFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/forms/FormsListFragment.kt
@@ -48,11 +48,11 @@ class FormsListFragment : ViewModelFragment<FormsViewModel>() {
         super.onViewCreated(view, savedInstanceState)
         viewModel.forms().observe(this, Observer {
             formAdapter.items = it
-            updateSyncStatus()
+            updateSyncSuccessfulNotice()
         })
         viewModel.syncVisibility().observe(this, Observer {
             syncGroup.visibility = it
-            updateSyncStatus()
+            updateSyncSuccessfulNotice()
         })
 
         viewModel.setTitle(getString(R.string.title_forms_list))
@@ -84,18 +84,16 @@ class FormsListFragment : ViewModelFragment<FormsViewModel>() {
     }
 
     /**
-     * Update the status of the sync indicators based on the values of the LiveDatas for forms and the sync
-     * Button. If we only use the syncVisibility() LiveData then we could get into a situation when the
-     * syncVisibility LiveData will trigger before the forms LiveData and we will have an empty screen which
-     * shows that everything is synchronized(and the info views will also jump around after the forms will be
-     * added).
+     * Update the visibility of a successful sync indicator based on the values of the LiveDatas for forms
+     * and the sync Button. If we only use the syncVisibility() LiveData then we could get into a situation
+     * when the syncVisibility LiveData will trigger before the forms LiveData and we will have an empty
+     * screen which shows that everything is synchronized(and the info views will also jump around after the
+     * forms will be loaded).
      */
-    private fun updateSyncStatus() {
-        val newSyncVisibility = viewModel.syncVisibility().value
+    private fun updateSyncSuccessfulNotice() {
+        val visibilityOfSyncBtn = viewModel.syncVisibility().value
         val areFormsVisible = viewModel.forms().value?.let { true } ?: false
-        newSyncVisibility?.let {
-            // remember that the sync visibility we use it's for the sync button so the success info will use
-            // the complementary visibility(ex: received View.VISIBLE should set View.GONE)
+        visibilityOfSyncBtn?.let {
             when (it) {
                 View.VISIBLE -> syncSuccessGroup.visibility = View.GONE
                 View.GONE -> syncSuccessGroup.visibility =

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/forms/FormsListFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/forms/FormsListFragment.kt
@@ -48,9 +48,11 @@ class FormsListFragment : ViewModelFragment<FormsViewModel>() {
         super.onViewCreated(view, savedInstanceState)
         viewModel.forms().observe(this, Observer {
             formAdapter.items = it
+            updateSyncStatus()
         })
         viewModel.syncVisibility().observe(this, Observer {
             syncGroup.visibility = it
+            updateSyncStatus()
         })
 
         viewModel.setTitle(getString(R.string.title_forms_list))
@@ -60,9 +62,11 @@ class FormsListFragment : ViewModelFragment<FormsViewModel>() {
             logAnalyticsEvent(Event.MANUAL_SYNC, Param(ParamKey.NUMBER_NOT_SYNCED, 0))
 
             if (!mContext.isOnline()) {
-                Snackbar.make(syncButton, getString(R.string.form_sync_no_internet), Snackbar.LENGTH_SHORT)
-                    .show()
-
+                Snackbar.make(
+                    syncButton,
+                    getString(R.string.form_sync_no_internet),
+                    Snackbar.LENGTH_SHORT
+                ).show()
                 return@setOnClickListener
             }
 
@@ -76,6 +80,28 @@ class FormsListFragment : ViewModelFragment<FormsViewModel>() {
                     .color(Color.TRANSPARENT)
                     .sizeResId(R.dimen.small_margin).build()
             )
+        }
+    }
+
+    /**
+     * Update the status of the sync indicators based on the values of the LiveDatas for forms and the sync
+     * Button. If we only use the syncVisibility() LiveData then we could get into a situation when the
+     * syncVisibility LiveData will trigger before the forms LiveData and we will have an empty screen which
+     * shows that everything is synchronized(and the info views will also jump around after the forms will be
+     * added).
+     */
+    private fun updateSyncStatus() {
+        val newSyncVisibility = viewModel.syncVisibility().value
+        val areFormsVisible = viewModel.forms().value?.let { true } ?: false
+        newSyncVisibility?.let {
+            // remember that the sync visibility we use it's for the sync button so the success info will use
+            // the complementary visibility(ex: received View.VISIBLE should set View.GONE)
+            when (it) {
+                View.VISIBLE -> syncSuccessGroup.visibility = View.GONE
+                View.GONE -> syncSuccessGroup.visibility =
+                    if (areFormsVisible) View.VISIBLE else View.GONE
+            }
+            Unit
         }
     }
 }

--- a/app/src/main/res/drawable/ic_sync_label_icon.xml
+++ b/app/src/main/res/drawable/ic_sync_label_icon.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="1000"
+    android:viewportHeight="1000">
+    <path
+        android:fillColor="#B2B2B2"
+        android:pathData="M 571,199 L 950,199 C 961,199 972,204 981,212 989,220 994,231 994,243 L 994,861 C 994,873 989,884 981,893 972,901 961,906 950,906 L 155,906 C 143,906 132,901 124,893 115,884 111,873 111,861 L 111,155 C 111,143 115,132 124,124 132,115 143,111 155,111 L 483,111 571,199 Z M 597,553 L 597,375 509,375 509,553 375,553 553,729 729,553 597,553 Z" />
+
+</vector>

--- a/app/src/main/res/layout/fragment_forms.xml
+++ b/app/src/main/res/layout/fragment_forms.xml
@@ -27,21 +27,20 @@
 
         <ImageView
             android:id="@+id/syncIcon"
-            android:layout_width="@dimen/small_icon_size"
-            android:layout_height="@dimen/small_icon_size"
-            android:contentDescription="@null"
+            android:layout_width="@dimen/medium_icon_size"
+            android:layout_height="@dimen/medium_icon_size"
             android:layout_marginEnd="@dimen/small_margin"
+            android:contentDescription="@null"
             app:layout_constraintBottom_toBottomOf="@id/syncInfo"
             app:layout_constraintEnd_toStartOf="@id/syncInfo"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/syncInfo"
-            app:layout_constraintVertical_bias="0"
             app:srcCompat="@drawable/ic_sync_label_icon" />
 
         <TextView
             android:id="@+id/syncInfo"
-            style="@style/Text.Label.Small"
+            style="@style/Text.Label"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/big_margin"
@@ -59,7 +58,7 @@
             style="@style/Button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin"
+            android:layout_marginTop="@dimen/small_margin"
             android:text="@string/sync_manual"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/syncInfo" />
@@ -76,29 +75,31 @@
 
         <ImageView
             android:id="@+id/syncIconSuccess"
-            android:layout_width="@dimen/small_icon_size"
-            android:layout_height="@dimen/small_icon_size"
+            android:layout_width="@dimen/medium_icon_size"
+            android:layout_height="@dimen/medium_icon_size"
+            android:layout_marginEnd="@dimen/small_margin"
             android:contentDescription="@null"
             app:layout_constraintBottom_toBottomOf="@id/syncInfoSuccess"
             app:layout_constraintEnd_toStartOf="@id/syncInfoSuccess"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/syncInfoSuccess"
+            app:layout_constraintTop_toBottomOf="@id/formsList"
             app:srcCompat="@drawable/ic_synced" />
 
         <TextView
             android:id="@+id/syncInfoSuccess"
-            style="@style/Text.Label.Small"
-            android:layout_width="wrap_content"
+            style="@style/Text.Label"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/big_margin"
+            android:layout_marginBottom="@dimen/big_margin"
             android:paddingStart="@dimen/small_margin"
             android:paddingEnd="@dimen/small_margin"
             android:text="@string/sync_info_success"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toEndOf="@id/syncIconSuccess"
-            app:layout_constraintTop_toBottomOf="@id/formsList" />
+            app:layout_constraintBottom_toBottomOf="parent" />
 
         <androidx.constraintlayout.widget.Group
             android:id="@+id/syncSuccessGroup"

--- a/app/src/main/res/layout/fragment_forms.xml
+++ b/app/src/main/res/layout/fragment_forms.xml
@@ -36,6 +36,7 @@
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/syncInfo"
+            app:layout_constraintVertical_bias="0"
             app:srcCompat="@drawable/ic_sync_label_icon" />
 
         <TextView
@@ -84,7 +85,6 @@
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/syncInfoSuccess"
-            app:layout_constraintTop_toBottomOf="@id/formsList"
             app:srcCompat="@drawable/ic_synced" />
 
         <TextView
@@ -92,14 +92,16 @@
             style="@style/Text.Label"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/big_margin"
             android:layout_marginBottom="@dimen/big_margin"
             android:paddingStart="@dimen/small_margin"
             android:paddingEnd="@dimen/small_margin"
             android:text="@string/sync_info_success"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toEndOf="@id/syncIconSuccess"
-            app:layout_constraintBottom_toBottomOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/formsList" />
 
         <androidx.constraintlayout.widget.Group
             android:id="@+id/syncSuccessGroup"

--- a/app/src/main/res/layout/fragment_forms.xml
+++ b/app/src/main/res/layout/fragment_forms.xml
@@ -27,30 +27,32 @@
 
         <ImageView
             android:id="@+id/syncIcon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/big_margin"
+            android:layout_width="@dimen/small_icon_size"
+            android:layout_height="@dimen/small_icon_size"
             android:contentDescription="@null"
-            android:src="@drawable/ic_sync_todo"
-            app:layout_constraintBottom_toTopOf="@+id/syncInfo"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginEnd="@dimen/small_margin"
+            app:layout_constraintBottom_toBottomOf="@id/syncInfo"
+            app:layout_constraintEnd_toStartOf="@id/syncInfo"
+            app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/formsList"
-            app:layout_constraintVertical_chainStyle="packed" />
+            app:layout_constraintTop_toTopOf="@id/syncInfo"
+            app:layout_constraintVertical_bias="0"
+            app:srcCompat="@drawable/ic_sync_label_icon" />
 
         <TextView
             android:id="@+id/syncInfo"
             style="@style/Text.Label.Small"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/small_margin"
-            android:gravity="center"
+            android:layout_marginTop="@dimen/big_margin"
             android:paddingStart="@dimen/small_margin"
             android:paddingEnd="@dimen/small_margin"
             android:text="@string/sync_info"
-            app:layout_constraintBottom_toTopOf="@+id/syncButton"
-            app:layout_constraintTop_toBottomOf="@id/syncIcon"
-            app:layout_constraintVertical_chainStyle="packed" />
+            app:layout_constraintBottom_toTopOf="@id/syncButton"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toEndOf="@id/syncIcon"
+            app:layout_constraintTop_toBottomOf="@id/formsList" />
 
         <Button
             android:id="@+id/syncButton"
@@ -68,7 +70,44 @@
             android:layout_height="0dp"
             android:visibility="gone"
             app:constraint_referenced_ids="syncButton,syncIcon,syncInfo"
+            tools:layout_editor_absoluteX="16dp"
+            tools:layout_editor_absoluteY="24dp"
             tools:visibility="visible" />
+
+        <ImageView
+            android:id="@+id/syncIconSuccess"
+            android:layout_width="@dimen/small_icon_size"
+            android:layout_height="@dimen/small_icon_size"
+            android:contentDescription="@null"
+            app:layout_constraintBottom_toBottomOf="@id/syncInfoSuccess"
+            app:layout_constraintEnd_toStartOf="@id/syncInfoSuccess"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/syncInfoSuccess"
+            app:srcCompat="@drawable/ic_synced" />
+
+        <TextView
+            android:id="@+id/syncInfoSuccess"
+            style="@style/Text.Label.Small"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/big_margin"
+            android:paddingStart="@dimen/small_margin"
+            android:paddingEnd="@dimen/small_margin"
+            android:text="@string/sync_info_success"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toEndOf="@id/syncIconSuccess"
+            app:layout_constraintTop_toBottomOf="@id/formsList" />
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/syncSuccessGroup"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:visibility="gone"
+            app:constraint_referenced_ids="syncIconSuccess,syncInfoSuccess"
+            tools:visibility="gone" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -88,7 +88,8 @@
     <!-- Forms list -->
     <string name="form_notes">Adaugă notă</string>
 
-    <string name="sync_info">Unele întrebări nu au fost sincronizate. Apasă butonul pentru a trimite răspunsurile din nou.</string>
+    <string name="sync_info">Unele răspunsuri sau note nu au fost sincronizate. Apasă butonul pentru a trimite răspunsurile din nou.</string>
+    <string name="sync_info_success">Toate răspunsurile și notele au fost sincronizate cu succes</string>
     <string name="sync_manual">Sincronizează datele manual</string>
 
     <string name="form_sync_no_internet">Ai nevoie de o conexiune la internet pentru a sincroniza datele!</string>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -61,5 +61,6 @@
 
     <dimen name="login_logo_icon_size">26dp</dimen>
     <dimen name="small_icon_size">16dp</dimen>
+    <dimen name="medium_icon_size">32dp</dimen>
     <dimen name="circle_indicator">10dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,7 @@
     <string name="form_notes">Add a message</string>
 
     <string name="sync_info">It appears that some of the questions have not been synchronised. Tap the button below to send the answers again</string>
+    <string name="sync_info_success">All the answers and notes were synchronized successfully</string>
     <string name="sync_manual">Synchronize data manually</string>
 
     <string name="form_sync_no_internet">You need to be connected to the internet to be able to sync the data!</string>


### PR DESCRIPTION
### What does it fix?

Closes #232 
My implementation will show the success string when there are no more things to upload and the previous sync button UI when there are things to upload. (Related to the icon, the arrow inside should probably be pointing up as we are uploading stuff).

Please comment for tweaks to the UI visual style if needed.

Note that there are differences between the strings posted by @aniri for english and the strings that appear in the attached images. I used the strings from the post.

### How has it been tested?

I tested manually between the two sync states.