### PR TITLE
Allow user to delete note files

### DIFF
--- a/app/src/main/java/ro/code4/monitorizarevot/helper/FileUtils.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/helper/FileUtils.kt
@@ -43,9 +43,13 @@ object FileUtils {
             contentResolver.query(uri, null, null, null, null)
                 ?.let { cursor ->
                     cursor.run {
-                        if (moveToFirst())
-                            getString(getColumnIndex(OpenableColumns.DISPLAY_NAME))
-                        else null
+                        if (moveToFirst()) {
+                            getString(getColumnIndex(OpenableColumns.DISPLAY_NAME))?.let { name ->
+                                "${System.currentTimeMillis()}_${name}"
+                            }
+                        } else {
+                            null
+                        }
                     }.also { cursor.close() }
                 }
         }.getOrNull()

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/notes/NoteFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/notes/NoteFragment.kt
@@ -14,6 +14,7 @@ import android.provider.Settings
 import android.text.TextWatcher
 import android.view.MotionEvent
 import android.view.View
+import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
@@ -79,12 +80,16 @@ class NoteFragment : ViewModelFragment<NoteViewModel>(), PermissionManager.Permi
         viewModel.filesNames().observe(viewLifecycleOwner, Observer {
             noteFileContainer.visibility = View.VISIBLE
             noteFileContainer.removeAllViews()
-            it.forEach { filename ->
-                val newTextView = requireActivity().layoutInflater.inflate(
+            it.forEachIndexed { index, filename ->
+                val attachmentView = requireActivity().layoutInflater.inflate(
                     R.layout.include_note_filename, noteFileContainer, false
-                ) as TextView
-                newTextView.text = filename
-                noteFileContainer.addView(newTextView)
+                ).also { view ->
+                    view.findViewById<TextView>(R.id.filenameText).text = filename
+                    view.findViewById<ImageButton>(R.id.deleteFile).setOnClickListener {
+                        viewModel.deleteFile(filename, index)
+                    }
+                }
+                noteFileContainer.addView(attachmentView)
             }
         })
         viewModel.submitCompleted().observe(this, Observer {

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/notes/NoteViewModel.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/notes/NoteViewModel.kt
@@ -32,7 +32,7 @@ class NoteViewModel : BaseFormViewModel() {
     private val notesLiveData = MutableLiveData<ArrayList<ListItem>>()
     private val filesNamesLiveData = MutableLiveData<List<String>>()
     private val submitCompletedLiveData = SingleLiveEvent<Void>()
-    private val noteFiles = mutableListOf<File>()
+    private var noteFiles = mutableListOf<File>()
     private val listObserver =
         Observer<List<Note>> { list ->
             processList(list)
@@ -129,6 +129,15 @@ class NoteViewModel : BaseFormViewModel() {
                 app.getString(R.string.error_note_file_copy_single)
             )
         }
+    }
+
+    fun deleteFile(filename: String, position: Int) {
+        val targetFiles = noteFiles.filter { it.absolutePath.endsWith("/$filename") }
+        if (targetFiles.isNotEmpty() && targetFiles.size == 1) {
+            targetFiles[0].delete()
+        }
+        noteFiles = noteFiles.filterIndexed { index, _ -> index != position }.toMutableList()
+        filesNamesLiveData.postValue(noteFiles.map { file -> file.name }.toList())
     }
 
     fun addUserGeneratedFile(file: File?) {

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/notes/NoteViewModel.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/notes/NoteViewModel.kt
@@ -134,7 +134,13 @@ class NoteViewModel : BaseFormViewModel() {
     fun deleteFile(filename: String, position: Int) {
         val targetFiles = noteFiles.filter { it.absolutePath.endsWith("/$filename") }
         if (targetFiles.isNotEmpty() && targetFiles.size == 1) {
-            targetFiles[0].delete()
+            try {
+                targetFiles[0].delete()
+            } catch (ex: Exception) {
+                // ignored
+                // this try-catch block will prevent the app from crashing if the file can't be deleted(which
+                // is ok because we dereference the file below and it is safe to remain on disk)
+            }
         }
         noteFiles = noteFiles.filterIndexed { index, _ -> index != position }.toMutableList()
         filesNamesLiveData.postValue(noteFiles.map { file -> file.name }.toList())

--- a/app/src/main/res/drawable/ic_note_file_delete.xml
+++ b/app/src/main/res/drawable/ic_note_file_delete.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="64"
+    android:viewportHeight="64">
+    <path
+        android:strokeColor="#ff0000"
+        android:strokeWidth="3"
+        android:pathData="M32,8 A24,24 0 1 1 31.99,8 z" />
+
+    <path
+        android:strokeColor="#ff0000"
+        android:strokeWidth="3"
+        android:pathData="M24,24 L40,40 M40,24 L24,40" />
+</vector>

--- a/app/src/main/res/layout/include_note_filename.xml
+++ b/app/src/main/res/layout/include_note_filename.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/filenameText"
-    style="@style/Text.Small"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/margin"
-    android:drawableStart="@drawable/ic_file"
-    android:drawablePadding="@dimen/small_margin"
-    tools:text="Frauda_0342.jpg" />
+    android:orientation="horizontal">
+
+    <TextView
+        android:id="@+id/filenameText"
+        style="@style/Text.Small"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_weight="1"
+        android:drawableStart="@drawable/ic_file"
+        android:drawablePadding="@dimen/small_margin"
+        tools:text="Frauda_0342.jpg" />
+
+    <ImageButton
+        android:id="@+id/deleteFile"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:background="@null"
+        android:contentDescription="@null"
+        app:srcCompat="@drawable/ic_note_file_delete" />
+</LinearLayout>


### PR DESCRIPTION
### What does it fix?

Closes #236 

The PR adds a delete ImageButton to each attached file so the user can delete it. The implementation also takes in consideration the possibility of the user attaching the same file twice or more and avoids deleting the file in this case.

This PR also fixes a bug where, if the user tried to add two different files which have the same name, the previous note files would be overwritten. To solve this I appended an additional timestamp to the selected file's name.

### How has it been tested?

Tested manually by adding and deleting some files to a note.
