### PR TITLE
Send count of unsynced items to analytics

### DIFF
--- a/app/src/main/java/ro/code4/monitorizarevot/ui/forms/FormsListFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/forms/FormsListFragment.kt
@@ -50,16 +50,16 @@ class FormsListFragment : ViewModelFragment<FormsViewModel>() {
             formAdapter.items = it
             updateSyncSuccessfulNotice()
         })
-        viewModel.syncVisibility().observe(viewLifecycleOwner, Observer {
-            syncGroup.visibility = it
+        viewModel.unSyncedDataCount().observe(viewLifecycleOwner, Observer {
+            syncGroup.visibility = if (it > 0) View.VISIBLE else View.GONE
             updateSyncSuccessfulNotice()
         })
 
         viewModel.setTitle(getString(R.string.title_forms_list))
 
         syncButton.setOnClickListener {
-            // TODO send number of unsynced items
-            logAnalyticsEvent(Event.MANUAL_SYNC, Param(ParamKey.NUMBER_NOT_SYNCED, 0))
+            val unSyncedCount = viewModel.unSyncedDataCount().value ?: 0
+            logAnalyticsEvent(Event.MANUAL_SYNC, Param(ParamKey.NUMBER_NOT_SYNCED, unSyncedCount))
 
             if (!mContext.isOnline()) {
                 Snackbar.make(
@@ -91,15 +91,13 @@ class FormsListFragment : ViewModelFragment<FormsViewModel>() {
      * forms will be loaded).
      */
     private fun updateSyncSuccessfulNotice() {
-        val visibilityOfSyncBtn = viewModel.syncVisibility().value
         val areFormsVisible = viewModel.forms().value?.let { true } ?: false
-        visibilityOfSyncBtn?.let {
-            when (it) {
+        viewModel.unSyncedDataCount().value?.let { unSyncedCount ->
+            when (if (unSyncedCount > 0) View.VISIBLE else View.GONE) {
                 View.VISIBLE -> syncSuccessGroup.visibility = View.GONE
                 View.GONE -> syncSuccessGroup.visibility =
                     if (areFormsVisible) View.VISIBLE else View.GONE
             }
-            Unit
         }
     }
 }

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/forms/FormsViewModel.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/forms/FormsViewModel.kt
@@ -25,7 +25,7 @@ class FormsViewModel : BaseFormViewModel() {
     private val formsLiveData = MutableLiveData<ArrayList<ListItem>>()
     private val selectedFormLiveData = MutableLiveData<FormDetails>()
     private val selectedQuestionLiveData = MutableLiveData<Pair<FormDetails, Question>>()
-    private val unSyncedDataCount = MediatorLiveData<Int>()
+    private val unSyncedDataCountLiveData = MediatorLiveData<Int>()
     private val navigateToNotesLiveData = MutableLiveData<Question?>()
     private val pollingStationLiveData = MutableLiveData<PollingStationInfo>()
 
@@ -39,13 +39,13 @@ class FormsViewModel : BaseFormViewModel() {
         val notSyncedNotesCount = repository.getNotSyncedNotes()
         val notSyncedPollingStationsCount = repository.getNotSyncedPollingStationsCount()
         fun update() {
-            unSyncedDataCount.value =
+            unSyncedDataCountLiveData.value =
                 (notSyncedQuestionsCount.value ?: 0) + (notSyncedNotesCount.value ?: 0) +
                         (notSyncedPollingStationsCount.value ?: 0)
         }
-        unSyncedDataCount.addSource(notSyncedQuestionsCount) { update() }
-        unSyncedDataCount.addSource(notSyncedNotesCount) { update() }
-        unSyncedDataCount.addSource(notSyncedPollingStationsCount) { update() }
+        unSyncedDataCountLiveData.addSource(notSyncedQuestionsCount) { update() }
+        unSyncedDataCountLiveData.addSource(notSyncedNotesCount) { update() }
+        unSyncedDataCountLiveData.addSource(notSyncedPollingStationsCount) { update() }
 
         disposables.add(Observable.combineLatest(
             repository.getAnswers(countyCode, pollingStationNumber),
@@ -127,7 +127,7 @@ class FormsViewModel : BaseFormViewModel() {
         selectedQuestionLiveData.postValue(Pair(selectedFormLiveData.value!!, question))
     }
 
-    fun unSyncedDataCount(): LiveData<Int> = unSyncedDataCount
+    fun unSyncedDataCount(): LiveData<Int> = unSyncedDataCountLiveData
 
     fun sync() {
         repository.syncData()


### PR DESCRIPTION
### What does it fix?

Closes #49 

This will send the number of currently unsynced items(this includes questions, notes and polling stations as a total) to analytics.

### How has it been tested?

Manually.