### PR TITLE
Fix incorrect selection of counties

### DIFF
--- a/app/src/main/java/ro/code4/monitorizarevot/ui/section/selection/PollingStationSelectionViewModel.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/section/selection/PollingStationSelectionViewModel.kt
@@ -39,6 +39,7 @@ class PollingStationSelectionViewModel : BaseViewModel() {
             .doOnSuccess {
                 counties.clear()
                 counties.addAll(it)
+                counties.sortBy { c -> c.order }
             }
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe({
@@ -54,11 +55,11 @@ class PollingStationSelectionViewModel : BaseViewModel() {
         val countyNames = counties.sortedBy { county -> county.order }.map { it.name }
 
         if (countyCode.isNullOrBlank()) {
-            countiesLiveData.postValue(Result.Success(listOf(app.getString(R.string.polling_station_spinner_choose)) + countyNames))
+            countiesLiveData.postValue(Result.Success(listOf(app.getString(R.string.polling_station_spinner_choose)) + countyNames.toList()))
         } else {
             hadSelectedCounty = true
             val selectedCountyIndex = counties.indexOfFirst { it.code == countyCode }
-            countiesLiveData.postValue(Result.Success(countyNames))
+            countiesLiveData.postValue(Result.Success(countyNames.toList()))
 
             if (selectedCountyIndex >= 0) {
                 selectionLiveData.postValue(Pair(selectedCountyIndex, pollingStationNumber))


### PR DESCRIPTION
### What does it fix?

Closes #246 

Fixes the bug with incorrect selection of the county when there's no internet.
This was happening due to the order of the counties. When there is internet the repository returns the counties returned by the API call which are sorted, when there is no internet the repository returns the counties from the database which are not sorted. The app then tries to select a county based on a sorted/unsorted list of counties which is problematic because we have a county("București") which jumps positions so any county between 0 and the position of "București" gets offset by one.

### How has it been tested?

Tested against the steps mentioned in the issue.