### PR TITLE
Fix UI for notes after changing stations

### DIFF
--- a/app/src/main/java/ro/code4/monitorizarevot/data/dao/NoteDao.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/data/dao/NoteDao.kt
@@ -3,6 +3,7 @@ package ro.code4.monitorizarevot.data.dao
 import androidx.lifecycle.LiveData
 import androidx.room.*
 import io.reactivex.Maybe
+import io.reactivex.Observable
 import ro.code4.monitorizarevot.data.model.Note
 
 @Dao
@@ -20,8 +21,18 @@ interface NoteDao {
         questionId: Int? = null
     ): LiveData<List<Note>>
 
+    @Query("SELECT * FROM note WHERE countyCode=:countyCode AND pollingStationNumber=:pollingStationNumber AND questionId=:questionId ORDER BY date DESC")
+    fun getNotesForQuestionAsObservable(
+        countyCode: String,
+        pollingStationNumber: Int,
+        questionId: Int? = null
+    ): Observable<List<Note>>
+
     @Query("SELECT * FROM note WHERE countyCode=:countyCode AND pollingStationNumber=:pollingStationNumber ORDER BY date DESC")
     fun getNotes(countyCode: String, pollingStationNumber: Int): LiveData<List<Note>>
+
+    @Query("SELECT * FROM note WHERE countyCode=:countyCode AND pollingStationNumber=:pollingStationNumber ORDER BY date DESC")
+    fun getNotesAsObservable(countyCode: String, pollingStationNumber: Int): Observable<List<Note>>
 
     @Query("SELECT * FROM note WHERE synced=:synced")
     fun getNotSyncedNotes(synced: Boolean = false): Maybe<List<Note>>

--- a/app/src/main/java/ro/code4/monitorizarevot/repositories/Repository.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/repositories/Repository.kt
@@ -285,6 +285,18 @@ class Repository : KoinComponent {
         }
     }
 
+    fun getNotesAsObservable(
+        countyCode: String,
+        pollingStationNumber: Int,
+        selectedQuestion: Question?
+    ): Observable<List<Note>> {
+        return if (selectedQuestion == null) {
+            db.noteDao().getNotesAsObservable(countyCode, pollingStationNumber)
+        } else {
+            db.noteDao().getNotesForQuestionAsObservable(countyCode, pollingStationNumber, selectedQuestion.id)
+        }
+    }
+
     fun getNotSyncedNotes(): LiveData<Int> = db.noteDao().getCountOfNotSyncedNotes()
 
     @SuppressLint("CheckResult")

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/forms/questions/QuestionsDetailsViewModel.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/forms/questions/QuestionsDetailsViewModel.kt
@@ -1,9 +1,11 @@
 package ro.code4.monitorizarevot.ui.forms.questions
 
+import io.reactivex.Observable
 import ro.code4.monitorizarevot.adapters.helper.ListItem
 import ro.code4.monitorizarevot.adapters.helper.MultiChoiceListItem
 import ro.code4.monitorizarevot.adapters.helper.QuestionDetailsListItem
 import ro.code4.monitorizarevot.adapters.helper.SingleChoiceListItem
+import ro.code4.monitorizarevot.data.model.Note
 import ro.code4.monitorizarevot.data.model.answers.AnsweredQuestion
 import ro.code4.monitorizarevot.data.model.answers.SelectedAnswer
 import ro.code4.monitorizarevot.data.pojo.AnsweredQuestionPOJO
@@ -86,4 +88,8 @@ class QuestionsDetailsViewModel : BaseQuestionViewModel() {
         repository.syncAnswers(countyCode, pollingStationNumber, selectedFormId)
     }
 
+    override fun provideNoteSource(): Observable<List<Note>> {
+        return repository.getNotesAsObservable(countyCode, pollingStationNumber, null)
+            .onErrorReturnItem(emptyList())
+    }
 }

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/forms/questions/QuestionsViewModel.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/forms/questions/QuestionsViewModel.kt
@@ -1,9 +1,11 @@
 package ro.code4.monitorizarevot.ui.forms.questions
 
+import io.reactivex.Observable
 import ro.code4.monitorizarevot.R
 import ro.code4.monitorizarevot.adapters.helper.ListItem
 import ro.code4.monitorizarevot.adapters.helper.QuestionListItem
 import ro.code4.monitorizarevot.adapters.helper.SectionListItem
+import ro.code4.monitorizarevot.data.model.Note
 import ro.code4.monitorizarevot.data.pojo.AnsweredQuestionPOJO
 import ro.code4.monitorizarevot.data.pojo.SectionWithQuestions
 
@@ -34,4 +36,8 @@ class QuestionsViewModel : BaseQuestionViewModel() {
         questionsLiveData.postValue(list)
     }
 
+    override fun provideNoteSource(): Observable<List<Note>> {
+        return repository.getNotesAsObservable(countyCode, pollingStationNumber, null)
+            .onErrorReturnItem(emptyList())
+    }
 }


### PR DESCRIPTION
### What does it fix?

Closes #250 

I refactored the parent `ViewModel` for questions to also use the list of notes that were saved for a county and polling station. I then use this data to properly implement the questions' hasNotes field.

### How has it been tested?

Manually, there were no UI glitches.