### PR TITLE
Attempt to fix language issues

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,7 +61,6 @@
         <activity
             android:name=".ui.section.VisitedPollingStationsActivity"
             android:parentActivityName=".ui.main.MainActivity"
-            android:label="@string/title_visited_stations"
             android:screenOrientation="portrait"
             android:launchMode="singleTop"
             android:theme="@style/AppTheme.NoActionBar"

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/base/ViewModelFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/base/ViewModelFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import ro.code4.monitorizarevot.helper.LocaleManager
 import ro.code4.monitorizarevot.interfaces.Layout
 import ro.code4.monitorizarevot.interfaces.ViewModelSetter
 
@@ -13,6 +14,7 @@ abstract class ViewModelFragment<out T : BaseViewModel> : BaseAnalyticsFragment(
     lateinit var mContext: Context
 
     override fun onAttach(context: Context) {
+        LocaleManager.wrapContext(context)
         super.onAttach(context)
         mContext = context
     }

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/section/PollingStationViewModel.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/section/PollingStationViewModel.kt
@@ -21,7 +21,7 @@ class PollingStationViewModel : BaseViewModel() {
     private val nextLiveData = SingleLiveEvent<Void>()
     private val nextToMainLiveData = SingleLiveEvent<Void>()
     private val titleLiveData = MutableLiveData<String>()
-    private val pollingStationLiveData = MutableLiveData<String>()
+    private val pollingStationLiveData = MutableLiveData<Pair<Int, String>>()
     private val arrivalTimeLiveData = MutableLiveData<String>()
     private val departureTimeLiveData = MutableLiveData<String>()
     private val selectedPollingStationLiveData = MutableLiveData<Pair<Int?, Int?>>()
@@ -43,15 +43,11 @@ class PollingStationViewModel : BaseViewModel() {
     fun departureTime(): LiveData<String> = departureTimeLiveData
     fun selectedPollingStation(): LiveData<Pair<Int?, Int?>> = selectedPollingStationLiveData
 
-    fun pollingStation(): LiveData<String> = pollingStationLiveData
+    fun pollingStation(): LiveData<Pair<Int, String>> = pollingStationLiveData
 
     fun getPollingStationBarText() {
         pollingStationLiveData.postValue(
-            app.getString(
-                R.string.polling_station,
-                selectedPollingStationNumber,
-                selectedCounty.name
-            )
+            Pair(selectedPollingStationNumber, selectedCounty.name)
         )
         getSelectedPollingStation()
     }

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/section/VisitedPollingStationsActivity.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/section/VisitedPollingStationsActivity.kt
@@ -32,6 +32,7 @@ class VisitedPollingStationsActivity : BaseActivity<VisitedPollingStationsViewMo
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_minimalist_arrow)
+        setTitle(R.string.title_visited_stations)
 
         visitedStationsAdapter = VisitedStationsAdapter(this) { station ->
             if (callingActivity?.className == PollingStationActivity::class.java.name) {

--- a/app/src/main/java/ro/code4/monitorizarevot/ui/section/details/PollingStationDetailsFragment.kt
+++ b/app/src/main/java/ro/code4/monitorizarevot/ui/section/details/PollingStationDetailsFragment.kt
@@ -37,7 +37,9 @@ class PollingStationDetailsFragment : ViewModelFragment<PollingStationViewModel>
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         viewModel.pollingStation().observe(viewLifecycleOwner, Observer {
-            pollingStationBarText.text = it
+            pollingStationBarText.text = getString(
+                R.string.polling_station, it.first, it.second
+            )
         })
         viewModel.setTitle(getString(R.string.title_polling_station))
         viewModel.getPollingStationBarText()


### PR DESCRIPTION
### What does it fix?

For #251 

> This error seems to show up when you go the the about screen, attempt to change the language, but pick the same language as before in the dropdown.

It doesn't happen just in that case, you can also see it if you navigate to the `Observer's guide` screen. This is happening because the forms, observer's guide and about are the 3 fragments in the navigation graph and when you go to one and then return to the others they get recreated. This seems to make the fragments to revert to the default locale(which is english) and ignore the locale we set(I don't understand why this happens). I tried something and it seems to work:

- to fix the wrong locale in the fragments I used a `LocaleManager.wrapContext()` in the base fragment to again apply the selected locale to the fragments.
- in the `VisitedPollingStationsActivity` I removed the label from the manifest(is applied before our locale is set and it relies on the system resources) and I set the title manually.
- in the `PollingStationsDetailsFragment` and its `ViewModel` I modified the `pollingStationLiveData` to return a pair of the needed values and let the fragment get the string. The ViewModel was using the application Context which is not going to have our locale applied to it. Here there's still a bug because I didn't changed the error strings(as above for pollingStationLiveData )when the user doesn't select area/gender/time because the `messageIdToastLiveData` is from the super class and it is also used in other places as well.

My changes seem to solve the bug but I'm not very comfortable with the code because I don't really get what is happening(and I don't know if I introduced bugs elsewhere). I made the PR so you could have a solution if you want it.

### How has it been tested?

I've played around with the app and it seems to keep the selected language.